### PR TITLE
fix: no more corrupted font in generated zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));


### PR DESCRIPTION
vinyl-fs v4 introduced a breaking change: src() now defaults to encoding: 'utf8'. We now disable the codec entirely.

The woff2 file in the zip was bigger than the original one. This lead to console warnings in browser.

Now, font file size is preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized build pipeline change that only affects how the release zip is packaged; minimal runtime impact outside packaging.
> 
> **Overview**
> Fixes binary asset corruption in the `zip` build by passing `{encoding: false}` to `gulp.src()` inside `zipper()`, ensuring files are streamed as raw buffers when generating the `dist/*.zip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d4658f6835726c28f5c21858f1f3f740f9bf2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->